### PR TITLE
isl 0.28

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,7 +7,7 @@ if [[ "$target_platform" == "win-64" ]]; then
   export LIBRARY_BIN=$(cygpath -u "$LIBRARY_BIN")
   export LIBRARY_INC=$(cygpath -u "$LIBRARY_INC")
   export LIBRARY_LIB=$(cygpath -u "$LIBRARY_LIB")
-  export LDFLAGS="-L${LIBRARY_LIB} -fuse-ld=lld -nostdlib -Xclang --dependent-lib=msvcrt"
+  export LDFLAGS="-L${LIBRARY_LIB} -fuse-ld=lld -nostdlib -Xclang --dependent-lib=ucrt"
   export PYTHON=:
   autoreconf -iv
   ./configure --prefix=$PREFIX --with-int=imath-32 --disable-shared || (cat config.log && false)

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,14 +3,8 @@
 if [[ "$target_platform" == "win-64" ]]; then
   export CFLAGS="$CFLAGS -O3 -Dstrdup=_strdup"
   export ac_cv_have_decl__BitScanForward=yes
-  export PREFIX=$(cygpath -u "$PREFIX")
-  export BUILD_PREFIX=$(cygpath -u "$BUILD_PREFIX")
-  export LIBRARY_PREFIX=$(cygpath -u "$LIBRARY_PREFIX")
-  export LIBRARY_BIN=$(cygpath -u "$LIBRARY_BIN")
-  export LIBRARY_INC=$(cygpath -u "$LIBRARY_INC")
-  export LIBRARY_LIB=$(cygpath -u "$LIBRARY_LIB")
-  autoreconf -ivf
-  ./configure --prefix="$PREFIX" --with-int=imath-32 --disable-shared || (cat config.log && false)
+  autoreconf -iv
+  ./configure --prefix=$PREFIX --with-int=imath-32 --disable-shared || (cat config.log && false)
   patch_libtool
 else
   # Get an updated config.sub and config.guess

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,8 +3,10 @@
 if [[ "$target_platform" == "win-64" ]]; then
   export CFLAGS="$CFLAGS -O3 -Dstrdup=_strdup"
   export ac_cv_have_decl__BitScanForward=yes
+  export PREFIX=$(cygpath -u "$PREFIX")
+  export BUILD_PREFIX=$(cygpath -u "$BUILD_PREFIX")
   autoreconf -ivf
-  ./configure --prefix=$PREFIX --with-int=imath-32 --disable-shared || (cat config.log && false)
+  ./configure --prefix="$PREFIX" --with-int=imath-32 --disable-shared || (cat config.log && false)
   patch_libtool
 else
   # Get an updated config.sub and config.guess

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,6 +5,10 @@ if [[ "$target_platform" == "win-64" ]]; then
   export ac_cv_have_decl__BitScanForward=yes
   export PREFIX=$(cygpath -u "$PREFIX")
   export BUILD_PREFIX=$(cygpath -u "$BUILD_PREFIX")
+  export LIBRARY_PREFIX=$(cygpath -u "$LIBRARY_PREFIX")
+  export LIBRARY_BIN=$(cygpath -u "$LIBRARY_BIN")
+  export LIBRARY_INC=$(cygpath -u "$LIBRARY_INC")
+  export LIBRARY_LIB=$(cygpath -u "$LIBRARY_LIB")
   autoreconf -ivf
   ./configure --prefix="$PREFIX" --with-int=imath-32 --disable-shared || (cat config.log && false)
   patch_libtool

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,7 +3,7 @@
 if [[ "$target_platform" == "win-64" ]]; then
   export CFLAGS="$CFLAGS -O3 -Dstrdup=_strdup"
   export ac_cv_have_decl__BitScanForward=yes
-  autoreconf -iv
+  autoreconf -ivf
   ./configure --prefix=$PREFIX --with-int=imath-32 --disable-shared || (cat config.log && false)
   patch_libtool
 else

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,6 +8,7 @@ if [[ "$target_platform" == "win-64" ]]; then
   export LIBRARY_INC=$(cygpath -u "$LIBRARY_INC")
   export LIBRARY_LIB=$(cygpath -u "$LIBRARY_LIB")
   export LDFLAGS="-L${LIBRARY_LIB} -fuse-ld=lld -nostdlib -Xclang --dependent-lib=msvcrt"
+  export PYTHON=:
   autoreconf -iv
   ./configure --prefix=$PREFIX --with-int=imath-32 --disable-shared || (cat config.log && false)
   patch_libtool

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,6 +3,11 @@
 if [[ "$target_platform" == "win-64" ]]; then
   export CFLAGS="$CFLAGS -O3 -Dstrdup=_strdup"
   export ac_cv_have_decl__BitScanForward=yes
+  export LIBRARY_PREFIX=$(cygpath -u "$LIBRARY_PREFIX")
+  export LIBRARY_BIN=$(cygpath -u "$LIBRARY_BIN")
+  export LIBRARY_INC=$(cygpath -u "$LIBRARY_INC")
+  export LIBRARY_LIB=$(cygpath -u "$LIBRARY_LIB")
+  export LDFLAGS="-L${LIBRARY_LIB} -fuse-ld=lld -nostdlib -Xclang --dependent-lib=msvcrt"
   autoreconf -iv
   ./configure --prefix=$PREFIX --with-int=imath-32 --disable-shared || (cat config.log && false)
   patch_libtool

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
 if [[ "$target_platform" == "win-64" ]]; then
+  # We'd like to build a dynamic library on Windows but
+  # isl_options_args is putting up a fight.  We'll keep the isl.lib
+  # (static) library name to align with conda-forge.
+
   # remove this substitution once autotools_clang_conda defaults to ucrt instead of msvcrt
   export CFLAGS="${CFLAGS/--dependent-lib=msvcrt/--dependent-lib=ucrt} -O3 -Dstrdup=_strdup"
   export ac_cv_have_decl__BitScanForward=yes

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [[ "$target_platform" == "win-64" ]]; then
-  export CFLAGS="$CFLAGS -O3 -Dstrdup=_strdup"
+  export CFLAGS="${CFLAGS/--dependent-lib=msvcrt/--dependent-lib=ucrt} -O3 -Dstrdup=_strdup"
   export ac_cv_have_decl__BitScanForward=yes
   export LIBRARY_PREFIX=$(cygpath -u "$LIBRARY_PREFIX")
   export LIBRARY_BIN=$(cygpath -u "$LIBRARY_BIN")

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,9 +8,8 @@ if [[ "$target_platform" == "win-64" ]]; then
   export LIBRARY_INC=$(cygpath -u "$LIBRARY_INC")
   export LIBRARY_LIB=$(cygpath -u "$LIBRARY_LIB")
   export LDFLAGS="-L${LIBRARY_LIB} -fuse-ld=lld -nostdlib -Xclang --dependent-lib=ucrt"
-  export PYTHON=:
   autoreconf -iv
-  ./configure --prefix=$PREFIX --with-int=imath-32 --disable-shared || (cat config.log && false)
+  ./configure --prefix=$PREFIX --with-int=imath-32 --disable-static || (cat config.log && false)
   patch_libtool
 else
   # Get an updated config.sub and config.guess

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,8 +8,9 @@ if [[ "$target_platform" == "win-64" ]]; then
   export LIBRARY_INC=$(cygpath -u "$LIBRARY_INC")
   export LIBRARY_LIB=$(cygpath -u "$LIBRARY_LIB")
   export LDFLAGS="-L${LIBRARY_LIB} -fuse-ld=lld -nostdlib -Xclang --dependent-lib=ucrt"
+  export PYTHON=:
   autoreconf -iv
-  ./configure --prefix=$PREFIX --with-int=imath-32 --disable-static || (cat config.log && false)
+  ./configure --prefix=$PREFIX --with-int=imath-32 --disable-shared || (cat config.log && false)
   patch_libtool
 else
   # Get an updated config.sub and config.guess

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,6 +4,10 @@ if [[ "$target_platform" == "win-64" ]]; then
   # We'd like to build a dynamic library on Windows but
   # isl_options_args is putting up a fight.  We'll keep the isl.lib
   # (static) library name to align with conda-forge.
+  #
+  # In addition, with no dynamic library, the Python module can't load
+  # it hence skipping the Python module tests (by making PYTHON be the
+  # no-op ":")
 
   # remove this substitution once autotools_clang_conda defaults to ucrt instead of msvcrt
   export CFLAGS="${CFLAGS/--dependent-lib=msvcrt/--dependent-lib=ucrt} -O3 -Dstrdup=_strdup"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 if [[ "$target_platform" == "win-64" ]]; then
+  # remove this substitution once autotools_clang_conda defaults to ucrt instead of msvcrt
   export CFLAGS="${CFLAGS/--dependent-lib=msvcrt/--dependent-lib=ucrt} -O3 -Dstrdup=_strdup"
   export ac_cv_have_decl__BitScanForward=yes
   export LIBRARY_PREFIX=$(cygpath -u "$LIBRARY_PREFIX")

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - libtool  # [unix]
     - autotools_clang_conda  # [win]
     - make  # [unix]
-    - msys2-patch  # [win]
+    - m2-patch  # [win]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - libtool  # [unix]
     - autotools_clang_conda  # [win]
     - make  # [unix]
-    - m2-patch  # [win]
+    - msys2-patch  # [win]
 
 test:
   commands:
@@ -35,17 +35,11 @@ test:
     - test -d "$PREFIX/include/isl"  # [unix]
 
 about:
-  home: https://libisl.sourceforge.io/
+  home: https://isl.gforge.inria.fr/
   license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: a thread-safe C library for manipulating sets and relations of integer points bounded by affine constraints.
-  description: |
-    isl is a thread-safe C library for manipulating sets and relations of integer
-    points bounded by affine constraints. It is used as the polyhedral loop
-    optimizer (Graphite) backend in GCC and by related compiler toolchain packages.
-  dev_url: https://repo.or.cz/isl.git
-  doc_url: https://libisl.sourceforge.io/user.html
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - libtool                # [unix]
     - autotools_clang_conda  # [win]
     - make                   # [unix]
-    - m2-patch               # [win]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,9 +21,11 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - libtool  # [unix]
     - autotools_clang_conda  # [win]
     - make  # [unix]
+    - msys2-patch  # [win]
 
 test:
   commands:
@@ -34,11 +36,17 @@ test:
     - test -d "$PREFIX/include/isl"  # [unix]
 
 about:
-  home: https://isl.gforge.inria.fr/
+  home: https://libisl.sourceforge.io/
   license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: a thread-safe C library for manipulating sets and relations of integer points bounded by affine constraints.
+  description: |
+    isl is a thread-safe C library for manipulating sets and relations of integer
+    points bounded by affine constraints. It is used as the polyhedral loop
+    optimizer (Graphite) backend in GCC and by related compiler toolchain packages.
+  dev_url: https://repo.or.cz/isl.git
+  doc_url: https://libisl.sourceforge.io/user.html
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,13 @@
+{% set name = "isl" %}
 {% set version = "0.28" %}
 
 package:
-  name: isl
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: isl-{{ version }}.tar.xz
-  url: https://libisl.sourceforge.io/isl-{{ version }}.tar.xz
+  fn: {{ name }}-{{ version }}.tar.xz
+  url: https://libisl.sourceforge.io/{{ name }}-{{ version }}.tar.xz
   sha256: 3dc31b8e1b18329e42d5dfbf84dd55e15c59b61569a2ab246f61497d9592f727
   patches:
     # From https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-isl/isl-0.14.1-no-undefined.patch
@@ -15,24 +16,24 @@ source:
 build:
   number: 0
   run_exports:
-    - {{ pin_subpackage("isl", max_pin="x.x") }}
+    - {{ pin_subpackage(name, max_pin="x.x") }}
 
 requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - libtool  # [unix]
+    - libtool                # [unix]
     - autotools_clang_conda  # [win]
-    - make  # [unix]
-    - m2-patch  # [win]
+    - make                   # [unix]
+    - m2-patch               # [win]
 
 test:
   commands:
-    - if not exist %LIBRARY_LIB%\\isl.lib exit 1  # [win]
-    - if not exist %LIBRARY_INC%\\isl\\options.h exit 1  # [win]
-    - test ! -f "$PREFIX/lib/libisl.a"  # [unix]
+    - if not exist %LIBRARY_LIB%\\isl.lib exit 1            # [win]
+    - if not exist %LIBRARY_INC%\\isl\\options.h exit 1     # [win]
+    - test ! -f "$PREFIX/lib/libisl.a"          # [unix]
     - test -f "$PREFIX/lib/libisl${SHLIB_EXT}"  # [unix]
-    - test -d "$PREFIX/include/isl"  # [unix]
+    - test -d "$PREFIX/include/isl"             # [unix]
 
 about:
   home: https://libisl.sourceforge.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.22.1" %}
+{% set version = "0.28" %}
 
 package:
   name: isl
@@ -7,13 +7,13 @@ package:
 source:
   fn: isl-{{ version }}.tar.xz
   url: https://libisl.sourceforge.io/isl-{{ version }}.tar.xz
-  sha256: 28658ce0f0bdb95b51fd2eb15df24211c53284f6ca2ac5e897acc3169e55b60f
+  sha256: 3dc31b8e1b18329e42d5dfbf84dd55e15c59b61569a2ab246f61497d9592f727
   patches:
     # From https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-isl/isl-0.14.1-no-undefined.patch
     - no_undefined.patch  # [win]
 
 build:
-  number: 3
+  number: 0
   run_exports:
     - {{ pin_subpackage("isl", max_pin="x.x") }}
 
@@ -21,21 +21,20 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - libtool                # [unix]
+    - libtool  # [unix]
     - autotools_clang_conda  # [win]
-    - make                   # [unix]
-    - m2-patch    # [win]
- 
+    - make  # [unix]
+
 test:
   commands:
-    - if not exist %LIBRARY_LIB%\\isl.lib exit 1            # [win]
-    - if not exist %LIBRARY_INC%\\isl\\options.h exit 1     # [win]
-    - test ! -f "$PREFIX/lib/libisl.a"          # [unix]
+    - if not exist %LIBRARY_LIB%\\isl.lib exit 1  # [win]
+    - if not exist %LIBRARY_INC%\\isl\\options.h exit 1  # [win]
+    - test ! -f "$PREFIX/lib/libisl.a"  # [unix]
     - test -f "$PREFIX/lib/libisl${SHLIB_EXT}"  # [unix]
-    - test -d "$PREFIX/include/isl"             # [unix]
+    - test -d "$PREFIX/include/isl"  # [unix]
 
 about:
-  home: http://isl.gforge.inria.fr/
+  home: https://isl.gforge.inria.fr/
   license: MIT
   license_family: MIT
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,11 +35,17 @@ test:
     - test -d "$PREFIX/include/isl"  # [unix]
 
 about:
-  home: https://isl.gforge.inria.fr/
+  home: https://libisl.sourceforge.io/
   license: MIT
   license_family: MIT
   license_file: LICENSE
   summary: a thread-safe C library for manipulating sets and relations of integer points bounded by affine constraints.
+  description: |
+    isl is a thread-safe C library for manipulating sets and relations of integer
+    points bounded by affine constraints. It is used as the polyhedral loop
+    optimizer (Graphite) backend in GCC and by related compiler toolchain packages.
+  dev_url: https://repo.or.cz/isl.git
+  doc_url: https://libisl.sourceforge.io/user.html
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - libtool  # [unix]
     - autotools_clang_conda  # [win]
     - make  # [unix]
-    - msys2-patch  # [win]
+    - m2-patch  # [win]
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,6 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - {{ stdlib('c') }}
     - libtool  # [unix]
     - autotools_clang_conda  # [win]
     - make  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,16 +31,17 @@ test:
     - test-isl.c
   requires:
     - {{ compiler('c') }}
+    - {{ stdlib('c') }}
   commands:
     - if not exist %LIBRARY_LIB%\\isl.lib exit 1            # [win]
     - if not exist %LIBRARY_INC%\\isl\\options.h exit 1     # [win]
-    - cl.exe /MD /I%LIBRARY_INC% test-isl.c /link %LIBRARY_LIB%\isl.lib  # [win]
-    - test-isl.exe                                          # [win]
+    - cl.exe /MD -I%LIBRARY_INC% %RECIPE_DIR%\test-isl.c /Fe"%cd%\test-isl.exe" /link /LIBPATH:"%LIBRARY_LIB%" isl.lib  # [win]
+    - .\test-isl.exe                                                                                                   # [win]
     - test ! -f "$PREFIX/lib/libisl.a"          # [unix]
     - test -f "$PREFIX/lib/libisl${SHLIB_EXT}"  # [unix]
     - test -d "$PREFIX/include/isl"             # [unix]
-    - $CC -o test-isl test-isl.c -I$PREFIX/include -L$PREFIX/lib -lisl  # [unix]
-    - ./test-isl                                                       # [unix]
+    - eval "${CC} -I ${PREFIX}/include -L ${PREFIX}/lib test-isl.c -lisl -Wl,-rpath,${PREFIX}/lib -o test-isl.out"  # [unix]
+    - ./test-isl.out                                                                                                # [unix]
 
 about:
   home: https://libisl.sourceforge.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,6 @@ requirements:
 test:
   commands:
     - if not exist %LIBRARY_LIB%\\isl.lib exit 1            # [win]
-    - if not exist %LIBRARY_BIN%\\libisl*.dll exit 1        # [win]
     - if not exist %LIBRARY_INC%\\isl\\options.h exit 1     # [win]
     - test ! -f "$PREFIX/lib/libisl.a"          # [unix]
     - test -f "$PREFIX/lib/libisl${SHLIB_EXT}"  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
   build:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ stdlib('c') }}
     - libtool                # [unix]
     - autotools_clang_conda  # [win]
     - make                   # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,6 +57,8 @@ about:
   doc_url: https://libisl.sourceforge.io/user.html
 
 extra:
+  skip-lints:
+    - reachable_url
   recipe-maintainers:
     - frol
     - isuruf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,12 +27,20 @@ requirements:
     - make                   # [unix]
 
 test:
+  files:
+    - test-isl.c
+  requires:
+    - {{ compiler('c') }}
   commands:
     - if not exist %LIBRARY_LIB%\\isl.lib exit 1            # [win]
     - if not exist %LIBRARY_INC%\\isl\\options.h exit 1     # [win]
+    - cl.exe /MD /I%LIBRARY_INC% test-isl.c /link %LIBRARY_LIB%\isl.lib  # [win]
+    - test-isl.exe                                          # [win]
     - test ! -f "$PREFIX/lib/libisl.a"          # [unix]
     - test -f "$PREFIX/lib/libisl${SHLIB_EXT}"  # [unix]
     - test -d "$PREFIX/include/isl"             # [unix]
+    - $CC -o test-isl test-isl.c -I$PREFIX/include -L$PREFIX/lib -lisl  # [unix]
+    - ./test-isl                                                       # [unix]
 
 about:
   home: https://libisl.sourceforge.io/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
 test:
   commands:
     - if not exist %LIBRARY_LIB%\\isl.lib exit 1            # [win]
+    - if not exist %LIBRARY_BIN%\\libisl*.dll exit 1        # [win]
     - if not exist %LIBRARY_INC%\\isl\\options.h exit 1     # [win]
     - test ! -f "$PREFIX/lib/libisl.a"          # [unix]
     - test -f "$PREFIX/lib/libisl${SHLIB_EXT}"  # [unix]

--- a/recipe/test-isl.c
+++ b/recipe/test-isl.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include <isl/set.h>
+
+int main(void) {
+	isl_ctx *ctx = isl_ctx_alloc();
+	isl_set *set = isl_set_read_from_str(ctx,
+		"{ [x, y] : x >= 0 and y >= 0 and x + y <= 10 }");
+	isl_bool empty = isl_set_is_empty(set);
+	isl_set_free(set);
+	isl_ctx_free(ctx);
+
+	if (empty != isl_bool_false) {
+		fprintf(stderr, "isl smoke test failed: expected non-empty set\n");
+		return 1;
+	}
+	printf("isl smoke test passed\n");
+	return 0;
+}


### PR DESCRIPTION
**Links**
- Jira: https://anaconda.atlassian.net/browse/PKG-16249
- Project home: https://libisl.sourceforge.io/
- Project source: https://repo.or.cz/isl.git
- Not on conda-forge; not a PyPI package

isl 0.22.1 → 0.28.

**Notes**
- Kept `m2-patch` (bot had dropped it) — `msys2-patch` conflicts with `autotools_clang_conda`'s `m2-make` dependency, unsolvable in this channel.
- Fixed win-64 link failure: `autotools_clang_conda`'s wrapper exports `LDFLAGS="-L${LIBRARY_LIB} ..."` using a native Windows path; embedded unquoted into a Makefile recipe, the shell strips its backslashes before libtool parses it, corrupting the `-L` arg and breaking the `libisl.la` link. Convert `LIBRARY_*` to POSIX via `cygpath` and rebuild `LDFLAGS` from the corrected value.
- Skip isl's own Python interface (`PYTHON=:`) on win — its `make check` self-test fails because `patch_libtool`'s hand-rolled DLL build doesn't set `dlname` correctly, and we don't ship a python-isl output anyway.
- `about/home` updated to `libisl.sourceforge.io` (old `isl.gforge.inria.fr` is dead); added `dev_url`/`doc_url`.
- Added `{{ name }}` jinja var, used throughout.